### PR TITLE
Fix remote call samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,9 +319,9 @@ IIncomingRemoteCallTracer incomingRemoteCallTracer = oneAgentSdk
 string incomingDynatraceStringTag = ...; // retrieve from incoming call metadata
  // link both sides of the remote call together
 incomingRemoteCallTracer.SetDynatraceStringTag(incomingDynatraceStringTag);
+incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
 
 incomingRemoteCallTracer.Start();
-incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
 try
 {
     ProcessRemoteCall();

--- a/samples/CombinedSamples.cs
+++ b/samples/CombinedSamples.cs
@@ -43,12 +43,11 @@ namespace Dynatrace.OneAgent.Sdk.Sample
 
                     string incomingDynatraceStringTag = outgoingDynatraceStringTag; // retrieve from incoming call metadata
                     incomingRemoteCallTracer.SetDynatraceStringTag(incomingDynatraceStringTag);
+                    incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
 
                     incomingRemoteCallTracer.Start();
                     try
                     {
-                        incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
-
                         // execute database request on server
                         DatabaseRequestTracerSamples.Sync_StartEnd();
                     }

--- a/samples/RemoteCallTracerSamples.cs
+++ b/samples/RemoteCallTracerSamples.cs
@@ -53,11 +53,11 @@ namespace Dynatrace.OneAgent.Sdk.Sample
 
             string incomingDynatraceStringTag = string.Empty; // retrieve from incoming call metadata
             incomingRemoteCallTracer.SetDynatraceStringTag(incomingDynatraceStringTag); // link both sides of the remote call together
+            incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
 
             incomingRemoteCallTracer.Start();
             try
             {
-                incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
                 ProcessRemoteCall();
             }
             catch (Exception e)
@@ -95,11 +95,11 @@ namespace Dynatrace.OneAgent.Sdk.Sample
 
                     string incomingDynatraceStringTag = outgoingDynatraceStringTag; // retrieve from incoming call metadata
                     incomingRemoteCallTracer.SetDynatraceStringTag(incomingDynatraceStringTag); // link both sides of the remote call together
+                    incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
 
                     incomingRemoteCallTracer.Start();
                     try
                     {
-                        incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
                         ProcessRemoteCall();
                     }
                     catch (Exception e)
@@ -150,11 +150,11 @@ namespace Dynatrace.OneAgent.Sdk.Sample
 
                     string incomingDynatraceStringTag = outgoingDynatraceStringTag; // retrieve from incoming call metadata
                     incomingRemoteCallTracer.SetDynatraceStringTag(incomingDynatraceStringTag); // link both sides of the remote call together
+                    incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
 
                     incomingRemoteCallTracer.Start();
                     try
                     {
-                        incomingRemoteCallTracer.SetProtocolName("MyRemoteCallProtocol");
                         ProcessRemoteCall();
                     }
                     catch (Exception e)


### PR DESCRIPTION
protocol name can only be set _before_ starting the tracer